### PR TITLE
Use more fitting Emojis for /drink and /water

### DIFF
--- a/config.json
+++ b/config.json
@@ -33,7 +33,7 @@
 			"messages": [
 				"Okay, enjoy your "
 			],
-			"symbol": "🍹"
+			"symbol": "🧉"
 		},
 		{
 			"name": "water",
@@ -46,7 +46,7 @@
 				"Der Bahnbabo sagt: Hydriert euch mit ",
 				"Okay, enjoy your "
 			],
-			"symbol": "🍼"
+			"symbol": "💧"
 		},
 		{
 			"name": "pizza",


### PR DESCRIPTION
`U+1F9C9` is labeled as `Mate Drink`:
![](https://e.unicode-table.com/orig/58/454876c99fb753142ee906c46b1ac6.png)

`U+1F376` is labeled as `Sake Bottle and Cup`:
![](https://e.unicode-table.com/orig/25/aa4aecaf90b8b885c650139d5f325c.png)

