### PR TITLE
Allowed MySQLdb package as in-place replacement for pymysql

### DIFF
--- a/mate_bot/state/dbhelper.py
+++ b/mate_bot/state/dbhelper.py
@@ -5,11 +5,10 @@ MateBot database management helper library
 import typing
 
 try:
-    import MySQLdb
+    import MySQLdb as pymysql
     import MySQLdb.connections
     import MySQLdb.cursors
 
-    pymysql = MySQLdb
     pymysql.connections = MySQLdb.connections
     pymysql.cursors = MySQLdb.cursors
 

--- a/mate_bot/state/dbhelper.py
+++ b/mate_bot/state/dbhelper.py
@@ -16,11 +16,12 @@ try:
 except ImportError:
     import pymysql
     pymysql.install_as_MySQLdb()
+    MySQLdb = None
 
 from mate_bot.config import config as _config
 
 
-QUERY_RESULT_TYPE = typing.Union[tuple, typing.List[typing.Dict[str, typing.Any]]]
+QUERY_RESULT_TYPE = typing.List[typing.Dict[str, typing.Any]]
 EXECUTE_TYPE = typing.Tuple[int, QUERY_RESULT_TYPE]
 EXECUTE_NO_COMMIT_TYPE = typing.Tuple[int, QUERY_RESULT_TYPE, pymysql.connections.Connection]
 
@@ -68,7 +69,7 @@ def execute_no_commit(
     if connection.open:
         with connection.cursor() as cursor:
             rows = cursor.execute(query, arguments)
-            result = cursor.fetchall()
+            result = list(cursor.fetchall())
     else:
         raise pymysql.err.OperationalError("No open connection")
     return rows, result, connection

--- a/mate_bot/state/dbhelper.py
+++ b/mate_bot/state/dbhelper.py
@@ -4,7 +4,18 @@ MateBot database management helper library
 
 import typing
 
-import pymysql
+try:
+    import MySQLdb
+    import MySQLdb.connections
+    import MySQLdb.cursors
+
+    pymysql = MySQLdb
+    pymysql.connections = MySQLdb.connections
+    pymysql.cursors = MySQLdb.cursors
+
+except ImportError:
+    import pymysql
+    pymysql.install_as_MySQLdb()
 
 from mate_bot.config import config as _config
 


### PR DESCRIPTION
This PR might fix #35. It will use the [`MySQLdb`](https://pypi.org/project/mysqlclient/) library when it is available. If not, it will fall back to using [`pymysql`](https://pypi.org/project/PyMySQL/). If the later is also not available, the database backend helper is not able to function properly, of course.

The `requirements.txt` file must be changed to reflect that at least one of those libraries is necessary. If both are availble, the bot uses `MySQLdb` preferred, at the moment.